### PR TITLE
Incremental Transition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,23 @@ FROM mcr.microsoft.com/devcontainers/base:ubuntu
 # Install vim for git commit messages
 RUN apt-get update && apt-get install -y vim
 
+# Install Docker CLI and Daemon
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Enable Docker service
+RUN systemctl enable docker.service && systemctl enable containerd.service
+
+# Add the default user to the docker group
+RUN usermod -aG docker vscode
+
 # Install Kurtosis CLI
 RUN echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
-RUN sudo apt update
-RUN sudo apt install kurtosis-cli
+RUN apt update
+RUN apt install kurtosis-cli

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -23,3 +23,8 @@ RUN usermod -aG docker vscode
 RUN echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
 RUN apt update
 RUN apt install kurtosis-cli
+
+# Install Foundry
+ENV FOUNDRY_DIR=/usr/local
+RUN curl -L https://foundry.paradigm.xyz | bash
+RUN foundryup

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,8 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
+# Install vim for git commit messages
+RUN apt-get update && apt-get install -y vim
+
 # Install Kurtosis CLI
 RUN echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
 RUN sudo apt update

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,6 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Install Kurtosis CLI
+RUN echo "deb [trusted=yes] https://apt.fury.io/kurtosis-tech/ /" | sudo tee /etc/apt/sources.list.d/kurtosis.list
+RUN sudo apt update
+RUN sudo apt install kurtosis-cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,5 +3,14 @@
         // Path is relative to the devcontainer.json file.
         "dockerfile": "Dockerfile"
     },
-    "runArgs": ["--privileged"]
+    "runArgs": [
+        "--privileged"
+    ],
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "JuanBlanco.solidity"
+            ]
+        }
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,48 +1,6 @@
 {
-    "name": "Example Devcontainer with Features",
-    "image": "ghcr.io/artifex1/audit-image-base:main",
-    // Features to add to the dev container. More info: https://containers.dev/features.
-    "features": {
-        // the web3 basics feature from this repository
-        "ghcr.io/artifex1/audit-image-features/web3-basics:latest": {}
-        // add any other features here that are required
-    },
-    // some security hardening
-    "runArgs": [
-        "--cap-drop=ALL",
-        "--security-opt=no-new-privileges",
-        "--security-opt=apparmor:docker-default"
-    ],
-    // Configure tool-specific properties.
-    "customizations": {
-        // Configure properties specific to VS Code.
-        "vscode": {
-            "settings": {
-                // Killswitch for automated tasks
-                "task.autoDetect": "off",
-                "task.problemMatchers.autoDetect": "off",
-                // Trust no one by default
-                "security.workspace.trust.enabled": false,
-                // Killswitch for telemetry
-                "telemetry.telemetryLevel": "off",
-                // Use zsh by default. Using bash might be more safe and stable.
-                "terminal.integrated.defaultProfile.linux": "zsh",
-                "terminal.integrated.profiles.linux": {
-                    "zsh": {
-                        "path": "/usr/bin/zsh"
-                    }
-                }
-                // add any other vscode settings here
-                // 1. open vscode and the control panel (cmd+shift+p)
-                // 2. search for "Preferences: Open Settings (JSON)"
-                // 3. copy the settings you want to add here
-            },
-            "extensions": [
-                // Here goes the list of extensions you want to have available
-                // in the devcontainer. You can get the list of extensions from
-                // the host machine with: code --list-extensions
-                // copy the list here, each extension wrapped in double quotes
-            ]
-        }
+    "build": {
+        // Path is relative to the devcontainer.json file.
+        "dockerfile": "Dockerfile"
     }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,5 +2,6 @@
     "build": {
         // Path is relative to the devcontainer.json file.
         "dockerfile": "Dockerfile"
-    }
+    },
+    "runArgs": ["--privileged"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,48 @@
+{
+    "name": "Example Devcontainer with Features",
+    "image": "ghcr.io/artifex1/audit-image-base:main",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    "features": {
+        // the web3 basics feature from this repository
+        "ghcr.io/artifex1/audit-image-features/web3-basics:latest": {}
+        // add any other features here that are required
+    },
+    // some security hardening
+    "runArgs": [
+        "--cap-drop=ALL",
+        "--security-opt=no-new-privileges",
+        "--security-opt=apparmor:docker-default"
+    ],
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            "settings": {
+                // Killswitch for automated tasks
+                "task.autoDetect": "off",
+                "task.problemMatchers.autoDetect": "off",
+                // Trust no one by default
+                "security.workspace.trust.enabled": false,
+                // Killswitch for telemetry
+                "telemetry.telemetryLevel": "off",
+                // Use zsh by default. Using bash might be more safe and stable.
+                "terminal.integrated.defaultProfile.linux": "zsh",
+                "terminal.integrated.profiles.linux": {
+                    "zsh": {
+                        "path": "/usr/bin/zsh"
+                    }
+                }
+                // add any other vscode settings here
+                // 1. open vscode and the control panel (cmd+shift+p)
+                // 2. search for "Preferences: Open Settings (JSON)"
+                // 3. copy the settings you want to add here
+            },
+            "extensions": [
+                // Here goes the list of extensions you want to have available
+                // in the devcontainer. You can get the list of extensions from
+                // the host machine with: code --list-extensions
+                // copy the list here, each extension wrapped in double quotes
+            ]
+        }
+    }
+}

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# ws from el-1-geth-lighthouse
+export L1_WS=ws://127.0.0.1:32772
+
+# http from cl-1-lighthouse-geth
+export L1_BEACON_URL=http://127.0.0.1:32776

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -21,8 +21,9 @@
 
 ### Linux dev container
 - I was having issues with `kurtosis` on my mac so I decided to try this in a linux dev container.
-- This means I created a `.devcontainer/devcontainer.json` file (copied from Seppi) and opened the project in the container.
-   - this should not impact anything about the code under development, but it means that any local commands I mention are running in the container environment.
+- Seppi's devcontainer (that he provided us in his workshop) was not suitable because it has a non-root user that cannot install new utilities.
+- I decided to follow [this explanation](https://code.visualstudio.com/docs/devcontainers/create-dev-container) to create a fresh one, and to install all the relevant dependencies in there.
+- Hopefully this also implies that other people can recreate my setup using the same Dockerfile.
 
 
 ### L1 Development Environment
@@ -30,5 +31,3 @@
    - the _L1 Node_ section of the `runme.md` file
    - the `network_params.yaml` file
 - I placed them in the main directory (not _taiko-client_) because they're not specifically related to the client.
-- Following the documentation, I ran `brew install kurtosis-tech/tap/kurtosis-cli`
-  - `kurtosis version` returns `CLI Version:   1.10.2`

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -1,0 +1,22 @@
+## Overview
+- This repository exists to modify the Taiko client so it works with our contracts.
+- I am finding the existing PRs difficult to follow. I intend to use this branch to make very incremental changes (probably copied from the other branches) so I can track what's going on.
+- I will update this description as a I go, so any commit on this branch will explain my current understanding and the current state of the codebase.
+
+## Background
+
+### PR 1
+- [Reference](https://github.com/OpenZeppelin/taiko-mono/pull/1) 
+- As I understand it, this adds the minimal rollup contracts to the repository and modifies the taiko client to interact with them.
+- It also includes a `run-me.md` file to explain how to set up a local environment.
+
+### PR 3
+- [Reference](https://github.com/OpenZeppelin/taiko-mono/pull/1)
+- This uses the latest version of the minimal rollup contracts (with the publication feed as part of the inbox).
+- It also starts the process of modifying the client to reorganise publications into blobs using the new format, and interpreting those blobs on the driver side.
+- It also uses the new anchor contract on the L2, and updates the genesis state accordingly.
+- It also renames the `run-me.md` file to `runme.md` and uses `kurtosis` for the L1 devnet instead of `anvil`.
+
+## Changes on this branch
+
+- So far, I have just updated this markdown file.

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -20,7 +20,9 @@
 ## Changes on this branch
 
 ### L1 Development Environment
-- I copied the _L1 Node_ section of the `runme.md` file from PR 3
-- I placed it in the main directory (not _taiko-client_) because it is not specifically related to the client.
+- I copied (from PR 3)
+   - the _L1 Node_ section of the `runme.md` file
+   - the `network_params.yaml` file
+- I placed them in the main directory (not _taiko-client_) because they're not specifically related to the client.
 - Following the documentation, I ran `brew install kurtosis-tech/tap/kurtosis-cli`
   - `kurtosis version` returns `CLI Version:   1.10.2`

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -34,6 +34,7 @@
 - I put the kurtosis install instructions in the `Dockerfile`. 
    - `kurtosis version` returns `CLI Version:   1.10.2`
 - The `scripts/run-kurtosis.sh` script can be used to create a kurtosis enclave.
+- I ran `cast wallet new` to produce a deployer account with a known private key, and prefunded this account in `network_params.yaml`
 
 #### Local output
 After running the script I get the error

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -33,3 +33,4 @@
 - I placed them in the main directory (not _taiko-client_) because they're not specifically related to the client.
 - I put the kurtosis install instructions in the `Dockerfile`. 
    - `kurtosis version` returns `CLI Version:   1.10.2`
+- The `scripts/run-kurtosis.sh` script can be used to create a kurtosis enclave.

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -19,6 +19,12 @@
 
 ## Changes on this branch
 
+### Linux dev container
+- I was having issues with `kurtosis` on my mac so I decided to try this in a linux dev container.
+- This means I created a `.devcontainer/devcontainer.json` file (copied from Seppi) and opened the project in the container.
+   - this should not impact anything about the code under development, but it means that any local commands I mention are running in the container environment.
+
+
 ### L1 Development Environment
 - I copied (from PR 3)
    - the _L1 Node_ section of the `runme.md` file

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -34,3 +34,57 @@
 - I put the kurtosis install instructions in the `Dockerfile`. 
    - `kurtosis version` returns `CLI Version:   1.10.2`
 - The `scripts/run-kurtosis.sh` script can be used to create a kurtosis enclave.
+
+#### Local output
+After running the script I get the error
+
+```
+Adding service with name 'blockscout-postgres' and image 'library/postgres:alpine'
+There was an error executing Starlark code 
+An error occurred executing instruction (number 44) at github.com/kurtosis-tech/postgres-package/main.star[115:40]:
+  add_service(name="blockscout-postgres", config=ServiceConfig(image="library/postgres:alpine", ports={"postgresql": PortSpec(number=5432, application_protocol="postgresql")}, files={}, cmd=["-c", "max_connections=1000"], env_vars={"POSTGRES_DB": "blockscout", "POSTGRES_PASSWORD": "MyPassword1!", "POSTGRES_USER": "postgres"}, max_cpu=1000, min_cpu=10, max_memory=1024, min_memory=32, node_selectors={}))
+  Caused by: Unexpected error occurred starting service 'blockscout-postgres'
+  Caused by: An error occurred starting the user service container for user service with UUID '69c33437a7d44f1788fab39a826396e1'
+  Caused by: Could not start Docker container from image 'library/postgres:alpine'.
+  Caused by: Could not start Docker container with ID 'e5ae609cef20671cab7f65c46f4462ab8cfef23462603590297b7dfe5f65c555'; logs are below:
+  --------------------- CONTAINER LOGS -----------------------
+  
+  ------------------- END CONTAINER LOGS --------------------
+  Caused by: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: unable to apply cgroup configuration: cannot enter cgroupv2 "/sys/fs/cgroup/docker" with domain controllers -- it is in threaded mode: unknown
+
+Error encountered running Starlark code.
+```
+
+and then the output
+
+```
+========================================== User Services ==========================================
+UUID           Name                                             Ports                                         Status
+26c40ed8583a   cl-1-lighthouse-geth                             http: 4000/tcp -> http://127.0.0.1:32779      RUNNING
+                                                                metrics: 5054/tcp -> http://127.0.0.1:32780   
+                                                                quic-discovery: 9001/udp -> 127.0.0.1:32771   
+                                                                tcp-discovery: 9000/tcp -> 127.0.0.1:32781    
+                                                                udp-discovery: 9000/udp -> 127.0.0.1:32770    
+ddadbc095284   cl-2-lighthouse-geth                             http: 4000/tcp -> http://127.0.0.1:32782      RUNNING
+                                                                metrics: 5054/tcp -> http://127.0.0.1:32783   
+                                                                quic-discovery: 9001/udp -> 127.0.0.1:32773   
+                                                                tcp-discovery: 9000/tcp -> 127.0.0.1:32784    
+                                                                udp-discovery: 9000/udp -> 127.0.0.1:32772    
+ae05ac94f991   el-1-geth-lighthouse                             engine-rpc: 8551/tcp -> 127.0.0.1:32771       RUNNING
+                                                                metrics: 9001/tcp -> http://127.0.0.1:32772   
+                                                                rpc: 8545/tcp -> 127.0.0.1:32769              
+                                                                tcp-discovery: 30303/tcp -> 127.0.0.1:32773   
+                                                                udp-discovery: 30303/udp -> 127.0.0.1:32768   
+                                                                ws: 8546/tcp -> 127.0.0.1:32770               
+62ca42aba9bf   el-2-geth-lighthouse                             engine-rpc: 8551/tcp -> 127.0.0.1:32776       RUNNING
+                                                                metrics: 9001/tcp -> http://127.0.0.1:32777   
+                                                                rpc: 8545/tcp -> 127.0.0.1:32774              
+                                                                tcp-discovery: 30303/tcp -> 127.0.0.1:32778   
+                                                                udp-discovery: 30303/udp -> 127.0.0.1:32769   
+                                                                ws: 8546/tcp -> 127.0.0.1:32775               
+2743a532c715   validator-key-generation-cl-validator-keystore   <none>                                        RUNNING
+3a6c03ce33ea   vc-1-geth-lighthouse                             metrics: 8080/tcp -> http://127.0.0.1:32785   RUNNING
+96dcdfff0a9a   vc-2-geth-lighthouse                             metrics: 8080/tcp -> http://127.0.0.1:32786   RUNNING
+```
+
+I will ignore the blockscout error for now.

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -31,3 +31,5 @@
    - the _L1 Node_ section of the `runme.md` file
    - the `network_params.yaml` file
 - I placed them in the main directory (not _taiko-client_) because they're not specifically related to the client.
+- I put the kurtosis install instructions in the `Dockerfile`. 
+   - `kurtosis version` returns `CLI Version:   1.10.2`

--- a/TRANSITION.md
+++ b/TRANSITION.md
@@ -19,4 +19,8 @@
 
 ## Changes on this branch
 
-- So far, I have just updated this markdown file.
+### L1 Development Environment
+- I copied the _L1 Node_ section of the `runme.md` file from PR 3
+- I placed it in the main directory (not _taiko-client_) because it is not specifically related to the client.
+- Following the documentation, I ran `brew install kurtosis-tech/tap/kurtosis-cli`
+  - `kurtosis version` returns `CLI Version:   1.10.2`

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -1,0 +1,7 @@
+participants:
+  - count: 2
+additional_services:
+  - blockscout
+  - dora
+  - prometheus
+  - grafana

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -5,3 +5,6 @@ additional_services:
   - dora
   - prometheus
   - grafana
+network_params:
+  # private key for deployer account 0xe96ca641ff5238b8c8c8b475c467b2456ffe64f61144275d64fe93957f532b8a
+  - prefunded_accounts: '{"0x82aB0a16b9ae55B761b6F581d7585697E27aAc89": {"balance": "10ETH"}'

--- a/network_params.yaml
+++ b/network_params.yaml
@@ -7,4 +7,4 @@ additional_services:
   - grafana
 network_params:
   # private key for deployer account 0xe96ca641ff5238b8c8c8b475c467b2456ffe64f61144275d64fe93957f532b8a
-  - prefunded_accounts: '{"0x82aB0a16b9ae55B761b6F581d7585697E27aAc89": {"balance": "10ETH"}'
+  prefunded_accounts: '{"0x82aB0a16b9ae55B761b6F581d7585697E27aAc89": {"balance": "10ETH"}}'

--- a/runme.md
+++ b/runme.md
@@ -1,0 +1,40 @@
+# Local Environment Setup
+
+These are the instructions to run a full L1 & L2 environment locally. There are likely easier ways to do this, but this is what worked for me :)
+
+## L1 Node
+
+1. Use kurtosis to run a local L1 devnet. Please refer to the [kurtosis documentation](https://github.com/ethpandaops/ethereum-package) for further details. However, in short this spins up a devnet with 2 execution client (EL) and 2 consensus nodes (CL) as well as some nice QoL features such as a block and beacon chain explorer.
+
+   ```sh
+   kurtosis run --enclave my-testnet github.com/ethpandaops/ethereum-package --args-file network_params.yaml
+   ```
+
+You will get an output similar to this:
+
+```bash
+UUID           Name                   Ports                                         Status
+681cd3d3a7a0   cl-1-lighthouse-geth   http: 4000/tcp -> http://127.0.0.1:32776      RUNNING
+                                      metrics: 5054/tcp -> http://127.0.0.1:32777
+                                      quic-discovery: 9001/udp -> 127.0.0.1:32770
+                                      tcp-discovery: 9000/tcp -> 127.0.0.1:32778
+                                      udp-discovery: 9000/udp -> 127.0.0.1:32769
+d61be60e1795   el-1-geth-lighthouse   engine-rpc: 8551/tcp -> 127.0.0.1:32773       RUNNING
+                                      metrics: 9001/tcp -> http://127.0.0.1:32774
+                                      rpc: 8545/tcp -> 127.0.0.1:32771
+                                      tcp-discovery: 30303/tcp -> 127.0.0.1:32775
+                                      udp-discovery: 30303/udp -> 127.0.0.1:32768
+                                      ws: 8546/tcp -> 127.0.0.1:32772
+
+```
+
+Replace the `.env`
+
+```bash
+# ws from el-1-geth-lighthouse
+export L1_WS=ws://127.0.0.1:32772
+
+# http from cl-1-lighthouse-geth
+export L1_BEACON_URL=http://127.0.0.1:32776
+```
+To interact with the EL you can use the rpc endpoint (i.e when deploying a contracts), in this cause it will be `http://127.0.0.1:32771`

--- a/scripts/run-kurtosis.sh
+++ b/scripts/run-kurtosis.sh
@@ -1,3 +1,4 @@
 sudo service docker start
 
+kurtosis clean -a
 kurtosis run --enclave my-testnet github.com/ethpandaops/ethereum-package --args-file network_params.yaml

--- a/scripts/run-kurtosis.sh
+++ b/scripts/run-kurtosis.sh
@@ -1,0 +1,3 @@
+sudo service docker start
+
+kurtosis run --enclave my-testnet github.com/ethpandaops/ethereum-package --args-file network_params.yaml


### PR DESCRIPTION
I started a branch to create an incremental transition from Taiko's deployment to ours. The intention is that every commit contains a small change, explained in the TRANSITION.md file. If anything breaks or seems inconsistent, then we can git bisect to find the relevant part of the codebase.

I am also making the changes in a devcontainer so that the build is repeatable. The plan is:
- run a local L1 network with kurtosis
- deploy the Taiko Inbox to this network
- run taiko-geth
- run taiko-client and configure it to interact with taiko-geth and the L1 network
- use forge cast to
  - send transactions to the taiko-geth mempool RPC
  - this should be processed by the taiko-client proposer
  - this should package the transactions and send them to the TaikoInbox
  - the taiko-client driver should listen for the events and decode the transactions
  - it should send them to taiko-geth to update the latest state

Once this is working, I want to morph their system into ours. This means:
- moving the validations from their inbox to taiko-client. Drop invalid publications
- update the logic so we produce empty blocks instead of dropping publications
- move any calldata (including metdata) that is no longer processed into blobs
- once the data is all in blobs, use our inbox contract
- optimise the blob formatting now that we are not constrained by the calldata requirements. This probably means removing any metadata that can be derived in the taiko-client.
- update the L2 genesis state to use our new L2 contracts (like the bridge)
- update the anchor contract, which probably means updating taiko-geth.


At this stage, I have just deployed kurtosis but I am pushing this PR now in case anyone finds it useful
